### PR TITLE
Handle exception for Python 3.4

### DIFF
--- a/lib/instance_billing_flavor_check/utils.py
+++ b/lib/instance_billing_flavor_check/utils.py
@@ -34,7 +34,7 @@ logging.basicConfig(
 )
 try:
     from cloudregister.registerutils import get_smt
-except ModuleNotFoundError as err:
+except ImportError:
     pass
 
 REGION_SRV_CLIENT_CONFIG_PATH = '/etc/regionserverclnt.cfg'


### PR DESCRIPTION
ModuleNotFoundError was introduced in Python 3.6,
Python 3.4 handles that as ImportError