### PR TITLE
Avoid reaching out to the same server more than necessary

### DIFF
--- a/lib/instance_billing_flavor_check/utils.py
+++ b/lib/instance_billing_flavor_check/utils.py
@@ -116,7 +116,8 @@ def _get_ips_from_etc_hosts():
             etc_hosts_ip_addr = etc_hosts_line.split()[0]
             try:
                 ipaddress.ip_address(etc_hosts_ip_addr)
-                rmt_ips_addr.append(etc_hosts_ip_addr)
+                if etc_hosts_ip_addr not in rmt_ips_addr:
+                    rmt_ips_addr.append(etc_hosts_ip_addr)
             except ValueError:
                 pass
 


### PR DESCRIPTION
When we collect the IP address(es) from the hosts file for the registration server the hosts file may have entries for the registry and the repository service. 2 DNS entries pointing to the same IP address. At present we will collect the IP address for both DNS names and then try to verify the flavor of the instance against that same IP in 2 different retry loops. Do not try to access a server more than once for a retry loop.